### PR TITLE
Added project option: dontUpdateTagsIfFileExists

### DIFF
--- a/plugin/indexer.vim
+++ b/plugin/indexer.vim
@@ -510,6 +510,20 @@ function! g:vimprj#dHooks['OnFileOpen']['indexer'](dParams)
 
             let l:dProject = l:dProjects[l:sProjectName]
             for l:sLibProjName in l:dProject.libraries
+               if has_key(l:dProjects[ l:sLibProjName ]['options'], 'dontUpdateTagsIfFileExists')
+                  let l:sDontUpdateTagsIfFileExists = l:dProjects[ l:sLibProjName ]['options'].dontUpdateTagsIfFileExists
+
+                  if (l:sDontUpdateTagsIfFileExists  == '1')
+                     let l:sTagsFile = l:dProjects[ l:sLibProjName ].tagsFilename
+
+                     if (filereadable(l:sTagsFile))
+                        let l:dProjects[ l:sLibProjName ].boolIndexed = 1
+                     endif
+                  elseif (l:sDontUpdateTagsIfFileExists != '0')
+                     call confirm ("Indexer warning:\nUnknown library dontUpdateTagsIfFileExists option: \"".l:sDontUpdateTagsIfFileExists."\"\nOnly \"0\" or \"1\" are supported.")
+                  endif
+               endif
+
                if (!l:dProjects[ l:sLibProjName ].boolIndexed)
                   call <SID>UpdateTagsForProject(l:sProjFileKey, l:sLibProjName, "", a:dParams['dVimprjRootParams'])
                endif


### PR DESCRIPTION
Hi Dmitry,

I've added a new project option: dontUpdateTagsIfFileExists
Works just like the global setting `g:indexer_dontUpdateTagsIfFileExists`, but only at the project level containing the option.

`option:dontUpdateTagsIfFileExists = "0"` (default)
`option:dontUpdateTagsIfFileExists = "1"`

This allows me to generate tags for some projects (eg. qt5) only once and not every time at startup.
Mainly used for projects which do not change or are too big to update at every startup.
The "main" project is unaffected and will still be updated at startup, unless the global option `g:indexer_dontUpdateTagsIfFileExists` is enabled.

Let me know what you think of this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dimonomid/indexer/4)
<!-- Reviewable:end -->
